### PR TITLE
Add Markstream React renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ React renderers for 3D graphics, command-line apps, video generation, PDF genera
 - [React PDF](https://github.com/diegomura/react-pdf) - Create PDF files using React.
 - [React Figma](https://github.com/react-figma/react-figma) - React renderer for Figma.
 - [Markdown to JSX](https://github.com/quantizor/markdown-to-jsx) - Markdown rendering for React.
+- [Markstream React](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for React, Next.js, and Remix, built for incomplete AI/chat output.
 
 ---
 


### PR DESCRIPTION
## Summary

Add Markstream React to the React Renderers section.

Markstream React is an actively maintained, MIT-licensed streaming Markdown renderer for React, Next.js, and Remix. It is designed for incomplete AI/chat output and has a live React playground at https://markstream-react.pages.dev/.

Thank you for maintaining this resource list.